### PR TITLE
Add relayer module

### DIFF
--- a/contracts/relayer/ILayerZeroClientRelayer.sol
+++ b/contracts/relayer/ILayerZeroClientRelayer.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import { ILayerZeroClientReceiver } from '../receiver/ILayerZeroClientReceiver.sol';
+import { ILayerZeroClientRelayerInternal } from './ILayerZeroClientRelayerInternal.sol';
+
+/**
+ * @title LayerZero Client Relayer interface
+ */
+interface ILayerZeroClientRelayer is
+    ILayerZeroClientReceiver,
+    ILayerZeroClientRelayerInternal
+{
+
+}

--- a/contracts/relayer/ILayerZeroClientRelayerInternal.sol
+++ b/contracts/relayer/ILayerZeroClientRelayerInternal.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import { ILayerZeroClientReceiverInternal } from '../receiver/ILayerZeroClientReceiverInternal.sol';
+
+/**
+ * @title Partial LayerZero Client Relayer interface needed by internal functions
+ */
+interface ILayerZeroClientRelayerInternal is ILayerZeroClientReceiverInternal {
+
+}

--- a/contracts/relayer/LayerZeroClientRelayer.sol
+++ b/contracts/relayer/LayerZeroClientRelayer.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import { LayerZeroClientReceiver } from '../receiver/LayerZeroClientReceiver.sol';
+import { ILayerZeroClientRelayer } from './ILayerZeroClientRelayer.sol';
+import { LayerZeroClientRelayerInternal } from './LayerZeroClientRelayerInternal.sol';
+
+/**
+ * @title LayerZero Client extension for support of cross-chain message receipt
+ */
+abstract contract LayerZeroClientRelayer is
+    ILayerZeroClientRelayer,
+    LayerZeroClientRelayerInternal,
+    LayerZeroClientReceiver
+{
+
+}

--- a/contracts/relayer/LayerZeroClientRelayerInternal.sol
+++ b/contracts/relayer/LayerZeroClientRelayerInternal.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import { LayerZeroClientReceiverInternal } from '../receiver/LayerZeroClientReceiverInternal.sol';
+import { ILayerZeroClientRelayer } from './ILayerZeroClientRelayer.sol';
+import { ILayerZeroClientRelayerInternal } from './ILayerZeroClientRelayerInternal.sol';
+
+/**
+ * @title LayerZero Client Relayer internal functions
+ * @dev derived from https://github.com/LayerZero-Labs/solidity-examples/ (MIT License)
+ */
+abstract contract LayerZeroClientRelayerInternal is
+    ILayerZeroClientRelayerInternal,
+    LayerZeroClientReceiverInternal
+{
+    /**
+     * @inheritdoc LayerZeroClientReceiverInternal
+     * @notice forward received LayerZero cross-chain message to encoded target address
+     * @dev TODO describe how to format relayable calls
+     */
+    function _handleLayerZeroMessage(
+        uint16,
+        bytes calldata,
+        uint64,
+        bytes calldata data
+    ) internal virtual override {
+        uint256 length = data.length;
+
+        unchecked {
+            address target = address(bytes20(data[length - 20:]));
+
+            (bool success, ) = target.call(data[:length - 20]);
+
+            if (!success) revert('TODO: return revert message');
+        }
+    }
+}

--- a/contracts/relayer/LayerZeroClientRelayerMock.sol
+++ b/contracts/relayer/LayerZeroClientRelayerMock.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import { LayerZeroClientRelayer } from './LayerZeroClientRelayer.sol';
+
+contract LayerZeroClientRelayerMock is LayerZeroClientRelayer {}


### PR DESCRIPTION
The relayer module allows a sender module on a remote chain to call functions on arbitrary contracts on the local chain using familiar transaction encoding: function selector + calldata.

The exact encoding format must be standardized before merging.